### PR TITLE
Fix Chakra UI theme import

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,7 +8,12 @@
 
 import React from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
-import theme from './src/@chakra-ui/gatsby-plugin/theme';
+// Use the theme provided by the Chakra UI Gatsby plugin. The plugin will
+// automatically resolve a local shadowed theme file at
+// `src/@chakra-ui/gatsby-plugin/theme.js` if it exists, otherwise it falls back
+// to the default theme. Importing it via the package name ensures that the
+// correct file is used and avoids referencing a non-existent local path.
+import theme from '@chakra-ui/gatsby-plugin/theme';
 
 export const wrapRootElement = ({ element }) => (
   <ChakraProvider theme={theme}>


### PR DESCRIPTION
## Summary
- use correct package path for Chakra UI theme

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_683f569c6d0083259a3905ef38e0bb26