### PR TITLE
Remove leftover gh-pages submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/.cache/gh-pages/


### PR DESCRIPTION
## Summary
- remove accidental git submodule left under `node_modules/.cache`
- ignore the gh-pages cache directory

## Testing
- `npm run build` *(fails: Can't resolve '@chakra-ui/gatsby-plugin/theme')*

------
https://chatgpt.com/codex/tasks/task_e_683f6389131483258d0360464c2fc71f