### PR TITLE
Fix CSS variable name typo

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -11,7 +11,7 @@
   --font-lg: 18px;
   --font-md: 16px;
   --font-sm: 14px;
-  --font-sx: 12px;
+  --font-xs: 12px;
   --line-height-loose: 1.75;
   --line-height-normal: 1.5;
   --line-height-dense: 1.1;


### PR DESCRIPTION
## Summary
- rename `--font-sx` to `--font-xs`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f639df194832598be542a8e8a723e