### PR TITLE
Add npm cache to GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,42 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+
+    - name: Restore npm cache
+      id: npm-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build
+
+    - name: Save npm cache
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Summary
- add a Node.js workflow for GitHub Actions
- restore and update the npm cache around `npm ci`

## Testing
- `npm test`
- `npm run build` *(fails: can't resolve '@chakra-ui/gatsby-plugin/theme')*

------
https://chatgpt.com/codex/tasks/task_e_683f7440bda08325ae4e2966a573feb9