### PR TITLE
Switch to npm ci for deterministic installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,13 @@ The fastest way to combine your favorite tools and APIs to build the fastest sit
 
 ## Running tests
 
-Install dependencies and run:
+Install dependencies with:
+
+```bash
+npm ci
+```
+
+Then run the test suite:
 
 ```bash
 npm test

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
 base = "focal"
-command = "npm run build"
+command = "npm ci && npm run build"
 publish = "public"
 


### PR DESCRIPTION
## Summary
- run `npm ci` before the Netlify build
- update README to show `npm ci` for dependency installation

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: lock file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_683f74228004832582a374892b81fb6c