### PR TITLE
Add layout and Bauhaus hero components

### DIFF
--- a/src/components/HeroBauhaus.jsx
+++ b/src/components/HeroBauhaus.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const HeroBauhaus = () => {
+  return (
+    <section className="relative flex h-96 items-center justify-center bg-bauhausYellow overflow-hidden">
+      <div className="absolute inset-0">
+        <div className="absolute top-0 left-0 h-48 w-48 bg-bauhausBlue"></div>
+        <div className="absolute bottom-0 right-0 h-32 w-32 bg-bauhausRed"></div>
+        <div className="absolute top-0 right-0 h-24 w-24 rounded-full border-4 border-bauhausBlack"></div>
+      </div>
+      <h1 className="relative text-4xl font-bold text-bauhausBlack">Welcome</h1>
+    </section>
+  );
+};
+
+export default HeroBauhaus;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Link } from "gatsby";
+
+const Layout = ({ children }) => {
+  return (
+    <div className="flex min-h-screen flex-col font-sans">
+      <header className="bg-bauhausRed text-white">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+          <Link to="/" className="font-bold hover:underline">
+            Zoe Rackley
+          </Link>
+          <nav className="space-x-4">
+            <Link to="/" className="hover:underline">
+              Home
+            </Link>
+            <Link to="/resume" className="hover:underline">
+              Resume
+            </Link>
+            <Link to="/contact" className="hover:underline">
+              Contact
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="flex-grow">{children}</main>
+      <footer className="bg-bauhausBlack py-4 text-center text-white">
+        © {new Date().getFullYear()} Zoe Rackley
+      </footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import Layout from "../components/Layout";
+import HeroBauhaus from "../components/HeroBauhaus";
+import Seo from "../components/seo";
+
+const IndexPage = () => (
+  <Layout>
+    <HeroBauhaus />
+    <section className="container mx-auto px-4 py-8">
+      <h2 className="mb-4 text-2xl font-bold">Featured Work</h2>
+      <p className="text-gray-700">Coming soon...</p>
+    </section>
+  </Layout>
+);
+
+export const Head = () => <Seo title="Home" />;
+
+export default IndexPage;


### PR DESCRIPTION
## Summary
- add Layout with header, nav and footer
- create HeroBauhaus geometric hero section
- build new `index.jsx` to use the layout and hero

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_683fe317842c832582ff8b8c968faed0