### PR TITLE
Add layout and Bauhaus hero components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "gatsby-transformer-sharp": "^5.13.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sass": "^1.89.1"
+        "sass": "^1.89.1",
+        "tailspin.css": "^1.0.7"
       },
       "devDependencies": {
         "@testing-library/react": "^14.3.1",
@@ -19651,6 +19652,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/tailspin.css": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailspin.css/-/tailspin.css-1.0.7.tgz",
+      "integrity": "sha512-U4t/BSnaSRYVk7qeFrzDt6xbfz7l3CJiiFlM5FsjhDu5W8mzWXweOoR50zJMBvM+Gah/hatGd1uoYepYbkonWw==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "gatsby-transformer-sharp": "^5.13.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sass": "^1.89.1"
+    "sass": "^1.89.1",
+    "tailspin.css": "^1.0.7"
   },
   "devDependencies": {
     "@testing-library/react": "^14.3.1",

--- a/src/components/HeroBauhaus.jsx
+++ b/src/components/HeroBauhaus.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const HeroBauhaus = () => {
+  return (
+    <section className="relative flex h-96 items-center justify-center bg-bauhausYellow overflow-hidden">
+      <div className="absolute inset-0">
+        <div className="absolute top-0 left-0 h-48 w-48 bg-bauhausBlue"></div>
+        <div className="absolute bottom-0 right-0 h-32 w-32 bg-bauhausRed"></div>
+        <div className="absolute top-0 right-0 h-24 w-24 rounded-full border-4 border-bauhausBlack"></div>
+      </div>
+      <h1 className="relative text-4xl font-bold text-bauhausBlack">Welcome</h1>
+    </section>
+  );
+};
+
+export default HeroBauhaus;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Link } from "gatsby";
+
+const Layout = ({ children }) => {
+  return (
+    <div className="flex min-h-screen flex-col font-sans">
+      <header className="bg-bauhausRed text-white">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+          <Link to="/" className="font-bold hover:underline">
+            Zoe Rackley
+          </Link>
+          <nav className="space-x-4">
+            <Link to="/" className="hover:underline">
+              Home
+            </Link>
+            <Link to="/resume" className="hover:underline">
+              Resume
+            </Link>
+            <Link to="/contact" className="hover:underline">
+              Contact
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="flex-grow">{children}</main>
+      <footer className="bg-bauhausBlack py-4 text-center text-white">
+        © {new Date().getFullYear()} Zoe Rackley
+      </footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,18 @@
+import * as React from "react";
+import Layout from "../components/Layout";
+import HeroBauhaus from "../components/HeroBauhaus";
+import Seo from "../components/seo";
+
+const IndexPage = () => (
+  <Layout>
+    <HeroBauhaus />
+    <section className="container mx-auto px-4 py-8">
+      <h2 className="mb-4 text-2xl font-bold">Featured Work</h2>
+      <p className="text-gray-700">Coming soon...</p>
+    </section>
+  </Layout>
+);
+
+export const Head = () => <Seo title="Home" />;
+
+export default IndexPage;


### PR DESCRIPTION
## Summary
- add Layout with header, nav and footer
- create HeroBauhaus geometric hero section
- build new `index.js` to use the layout and hero
- add tailspin.css dependency

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_683fe317842c832582ff8b8c968faed0