### PR TITLE
Use inline SVG placeholders for project images

### DIFF
--- a/src/components/AboutMe.jsx
+++ b/src/components/AboutMe.jsx
@@ -1,12 +1,21 @@
 import React from "react";
+import { StaticImage } from "gatsby-plugin-image";
 
 const AboutMe = () => (
   <section id="about" className="container mx-auto px-4 py-8 bg-gray-100">
     <h2 className="mb-4 text-2xl font-bold">About</h2>
-    <p className="text-gray-700">
-      I am a UX designer exploring Bauhaus-inspired interfaces and user
-      experiences. This site showcases selected projects and experiments.
-    </p>
+    <div className="flex flex-col items-center gap-4 md:flex-row">
+      <StaticImage
+        src="../images/profile.svg"
+        alt="Profile photo"
+        className="h-32 w-32 rounded-full"
+      />
+      <p className="text-gray-700">
+        Hello! I'm Zoe Rackley, a UX designer fascinated by the principles of
+        Bauhaus design. I enjoy blending geometry, color, and usability to craft
+        engaging digital experiences.
+      </p>
+    </div>
   </section>
 );
 

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+const ContactForm = () => (
+  <form name="contact" method="POST" data-netlify="true" className="space-y-4">
+    <input type="hidden" name="form-name" value="contact" />
+    <div>
+      <label htmlFor="name" className="block text-sm font-semibold">
+        Name
+      </label>
+      <input id="name" name="name" className="w-full border p-2" />
+    </div>
+    <div>
+      <label htmlFor="email" className="block text-sm font-semibold">
+        Email
+      </label>
+      <input type="email" id="email" name="email" className="w-full border p-2" />
+    </div>
+    <div>
+      <label htmlFor="message" className="block text-sm font-semibold">
+        Message
+      </label>
+      <textarea id="message" name="message" rows="4" className="w-full border p-2"></textarea>
+    </div>
+    <button type="submit" className="rounded bg-bauhausBlue px-4 py-2 font-semibold text-white">
+      Send
+    </button>
+  </form>
+);
+
+export default ContactForm;

--- a/src/components/FeaturedWork.jsx
+++ b/src/components/FeaturedWork.jsx
@@ -1,20 +1,13 @@
 import React from "react";
-
-const projects = [
-  { title: "Project One", description: "Coming soon" },
-  { title: "Project Two", description: "Coming soon" },
-  { title: "Project Three", description: "Coming soon" },
-];
+import projects from "../data/projects";
+import ProjectCard from "./ProjectCard";
 
 const FeaturedWork = () => (
   <section id="work" className="container mx-auto px-4 py-8">
     <h2 className="mb-4 text-2xl font-bold">Featured Work</h2>
-    <div className="grid gap-4 md:grid-cols-3">
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {projects.map((project) => (
-        <div key={project.title} className="rounded border p-4 shadow">
-          <h3 className="mb-2 text-xl font-semibold">{project.title}</h3>
-          <p className="text-gray-700">{project.description}</p>
-        </div>
+        <ProjectCard key={project.title} project={project} />
       ))}
     </div>
   </section>

--- a/src/components/HeroBauhaus.jsx
+++ b/src/components/HeroBauhaus.jsx
@@ -4,14 +4,15 @@ const HeroBauhaus = ({ intro, ctaText, ctaLink }) => {
   return (
     <section
       id="welcome"
-      className="relative flex h-96 flex-col items-center justify-center bg-bauhausYellow overflow-hidden text-center space-y-4"
+      className="relative flex h-[32rem] flex-col items-center justify-center bg-bauhausYellow overflow-hidden text-center space-y-4"
     >
       <div className="absolute inset-0">
         <div className="absolute top-0 left-0 h-48 w-48 bg-bauhausBlue"></div>
         <div className="absolute bottom-0 right-0 h-32 w-32 bg-bauhausRed"></div>
-        <div className="absolute top-0 right-0 h-24 w-24 rounded-full border-4 border-bauhausBlack"></div>
+        <div className="absolute top-10 right-10 h-24 w-24 rounded-full border-4 border-bauhausBlack"></div>
+        <div className="absolute bottom-10 left-1/2 h-16 w-16 -translate-x-1/2 bg-bauhausBlack"></div>
       </div>
-      <h1 className="relative text-4xl font-bold text-bauhausBlack">
+      <h1 className="relative text-5xl font-bold text-bauhausBlack">
         Welcome to my portfolio
       </h1>
       {intro && (

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { StaticImage } from "gatsby-plugin-image";
+
+const ProjectCard = ({ project }) => {
+  const renderImage = () => {
+    switch (project.image) {
+      case "../images/projects/project1.svg":
+        return (
+          <StaticImage
+            src="../images/projects/project1.svg"
+            alt={project.title}
+            className="w-full"
+          />
+        );
+      case "../images/projects/project2.svg":
+        return (
+          <StaticImage
+            src="../images/projects/project2.svg"
+            alt={project.title}
+            className="w-full"
+          />
+        );
+      case "../images/projects/project3.svg":
+        return (
+          <StaticImage
+            src="../images/projects/project3.svg"
+            alt={project.title}
+            className="w-full"
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-2 rounded border p-4 shadow bg-white">
+      {renderImage()}
+      <h3 className="text-xl font-semibold">{project.title}</h3>
+      <p className="text-gray-700">{project.description}</p>
+      <div className="space-x-4">
+        <a href={project.demo} className="text-bauhausBlue underline">
+          Demo
+        </a>
+        <a href={project.source} className="text-bauhausRed underline">
+          Code
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCard;

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1,0 +1,25 @@
+const projects = [
+  {
+    title: "Project One",
+    description: "A Bauhaus-themed dashboard interface.",
+    image: "../images/projects/project1.svg",
+    demo: "https://example.com/project-one",
+    source: "https://github.com/masterprocess/project-one",
+  },
+  {
+    title: "Project Two",
+    description: "Mobile app prototype exploring color and form.",
+    image: "../images/projects/project2.svg",
+    demo: "https://example.com/project-two",
+    source: "https://github.com/masterprocess/project-two",
+  },
+  {
+    title: "Project Three",
+    description: "Experiment with geometric typography.",
+    image: "../images/projects/project3.svg",
+    demo: "https://example.com/project-three",
+    source: "https://github.com/masterprocess/project-three",
+  },
+];
+
+export default projects;

--- a/src/images/profile.svg
+++ b/src/images/profile.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <circle cx="64" cy="48" r="24" fill="#777"/>
+  <rect x="32" y="80" width="64" height="32" fill="#777"/>
+</svg>

--- a/src/images/projects/project1.svg
+++ b/src/images/projects/project1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#eee"/>
+  <circle cx="60" cy="60" r="40" fill="#d00"/>
+  <rect x="150" y="40" width="100" height="100" fill="#00d"/>
+</svg>

--- a/src/images/projects/project2.svg
+++ b/src/images/projects/project2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#eee"/>
+  <circle cx="150" cy="100" r="50" fill="#f0f"/>
+  <rect x="30" y="30" width="80" height="80" fill="#0d0"/>
+</svg>

--- a/src/images/projects/project3.svg
+++ b/src/images/projects/project3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#eee"/>
+  <polygon points="150,20 280,180 20,180" fill="#ff0"/>
+</svg>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -3,6 +3,7 @@ import Layout from "../components/Layout";
 import HeroBauhaus from "../components/HeroBauhaus";
 import AboutMe from "../components/AboutMe";
 import FeaturedWork from "../components/FeaturedWork";
+import ContactForm from "../components/ContactForm";
 import Seo from "../components/seo";
 
 const IndexPage = () => (
@@ -16,9 +17,10 @@ const IndexPage = () => (
     <FeaturedWork />
     <section id="contact" className="container mx-auto px-4 py-8 bg-gray-100">
       <h2 className="mb-4 text-2xl font-bold">Get in Touch</h2>
-      <p className="text-gray-700">
+      <p className="mb-4 text-gray-700">
         Reach out to discuss potential collaborations or just say hello!
       </p>
+      <ContactForm />
     </section>
   </Layout>
 );


### PR DESCRIPTION
## Summary
- switch project asset paths from `.png` to `.svg`
- replace binary PNGs with small SVG placeholder images
- update components to reference the new SVG assets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68400e0315cc83258a35d8c5b11cd8ce