### PR TITLE
Add Header/Footer components and update Layout

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const Footer = () => (
+  <footer className="bg-bauhausBlack py-4 text-center text-white">
+    © {new Date().getFullYear()} Zoe Rackley
+  </footer>
+);
+
+export default Footer;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Link } from "gatsby";
+
+const Header = () => (
+  <header className="bg-bauhausRed text-white">
+    <div className="container mx-auto flex flex-wrap items-center justify-between px-4 py-4">
+      <Link to="/" className="font-bold hover:underline">
+        Zoe Rackley
+      </Link>
+      <nav className="flex flex-wrap space-x-4">
+        <Link to="/" className="hover:underline">Home</Link>
+        <Link to="/contact" className="hover:underline">Contact</Link>
+        <Link to="/resume" className="hover:underline">Resume</Link>
+      </nav>
+    </div>
+  </header>
+);
+
+export default Header;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,14 +1,13 @@
 import React from "react";
-import Navbar from "./Navbar";
+import Header from "./Header";
+import Footer from "./Footer";
 
-const Layout = ({ children }) => {
+const Layout = ({ children, showFooter = true }) => {
   return (
     <div className="flex min-h-screen flex-col font-sans">
-      <Navbar />
+      <Header />
       <main className="flex-grow">{children}</main>
-      <footer className="bg-bauhausBlack py-4 text-center text-white">
-        © {new Date().getFullYear()} Zoe Rackley
-      </footer>
+      {showFooter && <Footer />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `Header` component with links to `/`, `/contact`, `/resume`
- add standalone `Footer` component
- swap `Navbar` for `Header` in `Layout`
- allow optional footer display

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6840b3a9ec2c8325be41534008b6a152