### PR TITLE
Add contact and resume pages

### DIFF
--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -1,0 +1,17 @@
+import * as React from "react"
+import Layout from "../components/Layout"
+import ContactForm from "../components/ContactForm"
+import Seo from "../components/seo"
+
+const ContactPage = () => (
+  <Layout>
+    <section className="container mx-auto px-4 py-8">
+      <h1 className="mb-4 text-2xl font-bold">Contact Me</h1>
+      <ContactForm />
+    </section>
+  </Layout>
+)
+
+export const Head = () => <Seo title="Contact" />
+
+export default ContactPage

--- a/src/pages/resume.jsx
+++ b/src/pages/resume.jsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import Layout from "../components/Layout"
+import Seo from "../components/seo"
+
+const ResumePage = () => (
+  <Layout>
+    <section className="container mx-auto px-4 py-8">
+      <h1 className="mb-4 text-2xl font-bold">Resume</h1>
+      <p>
+        <a href="/resume.pdf" className="text-bauhausBlue underline">Download my resume</a>
+      </p>
+    </section>
+  </Layout>
+)
+
+export const Head = () => <Seo title="Resume" />
+
+export default ResumePage


### PR DESCRIPTION
## Summary
- add `ContactForm`-based contact page
- add resume download page with placeholder link

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6840b5371eb88325b8c0eadab6b588f6