### PR TITLE
Fix Tailwind stylesheet import

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,9 +1,7 @@
+import "./src/styles/global.css";
 /**
  * Implement Gatsby's Browser APIs in this file.
  *
  * See: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/
  */
-
-import "./src/styles/global.css";
-
 module.exports = {};


### PR DESCRIPTION
## Summary
- load Tailwind's global stylesheet at the top of `gatsby-browser.js`

## Testing
- `npm run clean`
- `npm run develop`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ba80f7cc8325b7b3c7e8702d933f