### PR TITLE
Fix blank build by using ESM and enable TypeScript

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -4,4 +4,4 @@ import "./src/styles/global.css";
  *
  * See: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/
  */
-module.exports = {};
+export {};

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const ContactForm = () => (
+const ContactForm: React.FC = () => (
   <form name="contact" method="POST" data-netlify="true" className="space-y-4">
     <input type="hidden" name="form-name" value="contact" />
     <div>
@@ -19,7 +19,7 @@ const ContactForm = () => (
       <label htmlFor="message" className="block text-sm font-semibold">
         Message
       </label>
-      <textarea id="message" name="message" rows="4" className="w-full border p-2"></textarea>
+      <textarea id="message" name="message" rows={4} className="w-full border p-2"></textarea>
     </div>
     <button type="submit" className="rounded bg-bauhausBlue px-4 py-2 font-semibold text-white">
       Send

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import Header from "./Header";
 import Footer from "./Footer";
 
-const Layout = ({ children, showFooter = true }) => {
+export interface LayoutProps {
+  children: ReactNode;
+  showFooter?: boolean;
+}
+
+const Layout = ({ children, showFooter = true }: LayoutProps) => {
   return (
     <div className="flex min-h-screen flex-col font-sans">
       <Header />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "lib": ["DOM", "ES2020"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "gatsby-*.ts"]
+}


### PR DESCRIPTION
## Summary
- switch `gatsby-browser.js` to TypeScript and proper ESM syntax
- introduce `tsconfig.json` for TypeScript compilation
- convert `Layout` and `ContactForm` components to `.tsx`

## Testing
- `npm run build`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6840c255f6a08325b3707dd82ddd17d8