### PR TITLE
Update tailwind palette and add google fonts

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,9 +4,25 @@
  * See: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/
  */
 
+const React = require("react")
+
 /**
  * @type {import('gatsby').GatsbySSR['onRenderBody']}
  */
-exports.onRenderBody = ({ setHtmlAttributes }) => {
+exports.onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
   setHtmlAttributes({ lang: `en` })
+  setHeadComponents([
+    <link key="gf-preconnect1" rel="preconnect" href="https://fonts.googleapis.com" />,
+    <link
+      key="gf-preconnect2"
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossOrigin="true"
+    />,
+    <link
+      key="gf-josefin"
+      href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />,
+  ])
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,10 +8,13 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        bauhausRed: '#ff0000',
-        bauhausYellow: '#ffff00',
-        bauhausBlue: '#0000ff',
-        bauhausBlack: '#000000',
+        bauhausRed: '#d04b41',
+        bauhausYellow: '#f4d35e',
+        bauhausBlue: '#577590',
+        bauhausBlack: '#2f2f2f',
+      },
+      fontFamily: {
+        sans: ['"Josefin Sans"', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- use muted Bauhaus shades in the Tailwind config
- include Josefin Sans font in Tailwind
- load Google Fonts via `setHeadComponents`

## Testing
- `npm run develop`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6840de7da5488325a6add3e133cb019a