### PR TITLE
Ensure blog text is black

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply text-black;
+}


### PR DESCRIPTION
## Summary
- ensure default typography uses black text by updating `global.css`

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68410157210c8325bd1d05a7d0b9473e