### PR TITLE
Add blog link to navigation

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,6 +9,7 @@ const Header = () => (
       </Link>
       <nav className="flex flex-wrap space-x-4">
         <Link to="/" className="hover:underline">Home</Link>
+        <Link to="/blog" className="hover:underline">Blog</Link>
         <Link to="/contact" className="hover:underline">Contact</Link>
         <Link to="/resume" className="hover:underline">Resume</Link>
       </nav>


### PR DESCRIPTION
## Summary
- add blog link to header navigation so the blog is discoverable

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6841018909a08325bff2734ac726ba92