### PR TITLE
Ensure blog text is black

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply text-black;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,27 @@ module.exports = {
       fontFamily: {
         sans: ['"Josefin Sans"', "sans-serif"],
       },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': theme('colors.black'),
+            '--tw-prose-headings': theme('colors.black'),
+            '--tw-prose-lead': theme('colors.black'),
+            '--tw-prose-links': theme('colors.black'),
+            '--tw-prose-bold': theme('colors.black'),
+            '--tw-prose-counters': theme('colors.black'),
+            '--tw-prose-bullets': theme('colors.black'),
+            '--tw-prose-hr': theme('colors.black'),
+            '--tw-prose-quotes': theme('colors.black'),
+            '--tw-prose-quote-borders': theme('colors.black'),
+            '--tw-prose-captions': theme('colors.black'),
+            '--tw-prose-code': theme('colors.black'),
+            '--tw-prose-pre-code': theme('colors.black'),
+            '--tw-prose-th-borders': theme('colors.black'),
+            '--tw-prose-td-borders': theme('colors.black'),
+          },
+        },
+      }),
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION
## Summary
- override default typography colors to black in Tailwind config

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68410157210c8325bd1d05a7d0b9473e