### PR TITLE
Fix blog overlap with nav

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -11,7 +11,7 @@ const Layout = ({ children, showFooter = true }: LayoutProps) => {
   return (
     <div className="flex min-h-screen flex-col font-sans">
       <Header />
-      <main className="flex-grow">{children}</main>
+      <main className="flex-grow pt-20">{children}</main>
       {showFooter && <Footer />}
     </div>
   );


### PR DESCRIPTION
## Summary
- add padding-top to Layout so blog posts don't overlap with the navigation

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68410c9f60fc8325856664abe9657fd5