### PR TITLE
Fix MDX table rendering

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,8 @@
  */
 
 /** @type {import("gatsby").GatsbyConfig} */
+const remarkGfm = require("remark-gfm");
+
 module.exports = {
   siteMetadata: {
     title: `Zoe Rackley — UX Design`,
@@ -43,7 +45,7 @@ module.exports = {
       options: {
         extensions: [`.mdx`, `.md`],
         mdxOptions: {
-          remarkPlugins: [require(`remark-gfm`)],
+          remarkPlugins: [remarkGfm],
           // rehypePlugins: [],           // add any HTML-side plugins later
         },
         gatsbyRemarkPlugins: [], // if you decide to use gatsby-remark plugins

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -29,7 +29,7 @@ export default function BlogPost({
   const { frontmatter } = data.mdx;
   return (
     <Layout>
-      <article className="prose md:prose-lg mx-auto pt-20">
+      <article className="prose md:prose-lg dark:prose-invert mx-auto pt-20">
         <h1>{frontmatter.title}</h1>
         <p className="text-sm opacity-70">{frontmatter.date}</p>
         {children}


### PR DESCRIPTION
## Summary
- fix MDX table parsing by correctly loading `remark-gfm`
- enable `dark:prose-invert` styling for blog posts

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: config object uses unsupported `extends` key)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68413b28fc8c8325a1f9c5d1c0d85b63