### PR TITLE
Preload site fonts from Google

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -28,5 +28,16 @@ exports.onRenderBody = ({ setHtmlAttributes, setHeadComponents }) => {
       href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&display=swap"
       rel="stylesheet"
     />,
+    <link
+      key="gf-preload-dm-inter-ibm"
+      rel="preload"
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter&family=IBM+Plex+Mono&display=swap"
+      as="style"
+    />,
+    <link
+      key="gf-dm-inter-ibm"
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter&family=IBM+Plex+Mono&display=swap"
+      rel="stylesheet"
+    />,
   ]);
 };


### PR DESCRIPTION
## Summary
- add preload and stylesheet links for DM Serif Display, Inter, and IBM Plex Mono
- keep existing preconnect links
- confirm global stylesheet is imported in `gatsby-browser.ts`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685c75677a60832582424a71228df827