### PR TITLE
Add design system utilities

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,4 +1,5 @@
 import './src/styles/global.css';
+import './src/styles/design-system.scss';
 /**
  * Implement Gatsby's Browser APIs in this file.
  *

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import Header from './Header';
 import Footer from './Footer';
+import Wrapper from './Wrapper';
 
 export interface LayoutProps {
   children: ReactNode;
@@ -11,7 +12,9 @@ const Layout = ({ children, showFooter = true }: LayoutProps) => {
   return (
     <div className="flex min-h-screen flex-col font-sans">
       <Header />
-      <main>{children}</main>
+      <main>
+        <Wrapper>{children}</Wrapper>
+      </main>
       {showFooter && <Footer />}
     </div>
   );

--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from 'react';
+
+export interface WrapperProps {
+  children: ReactNode;
+}
+
+const Wrapper = ({ children }: WrapperProps) => (
+  <div className="content-wrapper">{children}</div>
+);
+
+export default Wrapper;

--- a/src/styles/design-system.scss
+++ b/src/styles/design-system.scss
@@ -1,1 +1,21 @@
-/* Placeholder for future design system styles */
+:root {
+  --space-1: 6px;
+  --space-2: 12px;
+}
+
+/* Grid utility for 12 equal columns */
+.grid-cols-12 {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: var(--space-1);
+}
+
+/* Generic wrapper constraining content width */
+.content-wrapper {
+  width: 100%;
+  max-width: 72ch;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,10 @@ module.exports = {
           },
         },
       }),
+      spacing: {
+        'space-1': '6px',
+        'space-2': '12px',
+      },
     },
   },
   plugins: [require('@tailwindcss/typography')],


### PR DESCRIPTION
## Summary
- add basic spacing variables and grid-cols-12 utility
- load design-system styles in gatsby-browser
- use a new Wrapper component to constrain main width
- expose custom spacing scale in Tailwind config

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685c7585b4488325ac59b36fb1b170f9