### PR TITLE
feat: adopt noir portfolio styling

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,8 +2,145 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Dark Noir theme variables */
+:root {
+  --font-size: 16px;
+  --background: #0a0a0a;
+  --foreground: #e5e5e5;
+  --card: #1a1a1a;
+  --card-foreground: #e5e5e5;
+  --popover: #1a1a1a;
+  --popover-foreground: #e5e5e5;
+  --primary: #e5e5e5;
+  --primary-foreground: #0a0a0a;
+  --secondary: #2a2a2a;
+  --secondary-foreground: #e5e5e5;
+  --muted: #2a2a2a;
+  --muted-foreground: #9ca3af;
+  --accent: #2a2a2a;
+  --accent-foreground: #e5e5e5;
+  --destructive: #dc2626;
+  --destructive-foreground: #ffffff;
+  --border: #2a2a2a;
+  --input: #2a2a2a;
+  --input-background: #1a1a1a;
+  --switch-background: #2a2a2a;
+  --ring: #4a5568;
+  --chart-1: #dc2626;
+  --chart-2: #6b7280;
+  --chart-3: #4b5563;
+  --chart-4: #374151;
+  --chart-5: #1f2937;
+  --radius: 0.375rem;
+  --sidebar: #1a1a1a;
+  --sidebar-foreground: #e5e5e5;
+  --sidebar-primary: #e5e5e5;
+  --sidebar-primary-foreground: #0a0a0a;
+  --sidebar-accent: #2a2a2a;
+  --sidebar-accent-foreground: #e5e5e5;
+  --sidebar-border: #2a2a2a;
+  --sidebar-ring: #4a5568;
+
+  /* Custom Noir Colors */
+  --noir-red: #dc2626;
+  --noir-red-hover: #ef4444;
+  --noir-black: #0a0a0a;
+  --noir-dark-gray: #1a1a1a;
+  --noir-gray: #2a2a2a;
+  --noir-light-gray: #6b7280;
+  --noir-white: #e5e5e5;
+}
+
+/* Light theme override */
+.light {
+  --background: #f8f9fa;
+  --foreground: #1a1a1a;
+  --card: #ffffff;
+  --card-foreground: #1a1a1a;
+  --popover: #ffffff;
+  --popover-foreground: #1a1a1a;
+  --primary: #1a1a1a;
+  --primary-foreground: #ffffff;
+  --secondary: #f1f5f9;
+  --secondary-foreground: #1a1a1a;
+  --muted: #f1f5f9;
+  --muted-foreground: #6b7280;
+  --accent: #f1f5f9;
+  --accent-foreground: #1a1a1a;
+  --destructive: #dc2626;
+  --destructive-foreground: #ffffff;
+  --border: #e2e8f0;
+  --input: #ffffff;
+  --input-background: #ffffff;
+  --switch-background: #e2e8f0;
+  --ring: #94a3b8;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #1a1a1a;
+  --sidebar-primary: #1a1a1a;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f1f5f9;
+  --sidebar-accent-foreground: #1a1a1a;
+  --sidebar-border: #e2e8f0;
+  --sidebar-ring: #94a3b8;
+}
+
 body {
   @apply text-noir-text bg-noir-background;
+}
+
+html {
+  scroll-behavior: smooth;
+  font-size: var(--font-size);
+}
+
+/* Custom Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #1a1a1a;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #dc2626;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #ef4444;
+}
+
+/* Animated & utility classes */
+.magnetic {
+  transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.liquid-shape {
+  border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%;
+  animation: liquid 8s ease-in-out infinite;
+}
+
+.text-reveal {
+  overflow: hidden;
+}
+
+.text-reveal-inner {
+  transform: translateY(100%);
+  transition: transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.text-reveal.revealed .text-reveal-inner {
+  transform: translateY(0);
+}
+
+.parallax-container {
+  transform-style: preserve-3d;
+  perspective: 1000px;
+}
+
+.parallax-element {
+  transform: translateZ(0);
 }
 
 @layer utilities {
@@ -12,6 +149,7 @@ body {
   .prose thead th { @apply border-b border-slate-500 px-4 py-2 text-left font-semibold; }
   .prose tbody td { @apply border-b border-slate-700/40 px-4 py-2; }
 }
+
 @layer components {
   .glitch {
     position: relative;
@@ -48,3 +186,64 @@ body {
     clip-path: inset(70% 0 0 0);
   }
 }
+
+@keyframes glitch-1 {
+  0%, 100% { transform: translate(0); opacity: 1; }
+  10% { transform: translate(-2px, 2px); opacity: 0.8; }
+  20% { transform: translate(-4px, -2px); opacity: 0.9; }
+  30% { transform: translate(2px, 1px); opacity: 0.7; }
+  40% { transform: translate(1px, -1px); opacity: 0.8; }
+  50% { transform: translate(-1px, 2px); opacity: 0.9; }
+  60% { transform: translate(-3px, 1px); opacity: 0.7; }
+  70% { transform: translate(2px, 1px); opacity: 0.8; }
+  80% { transform: translate(-1px, -1px); opacity: 0.9; }
+  90% { transform: translate(1px, 2px); opacity: 0.7; }
+}
+
+@keyframes glitch-2 {
+  0%, 100% { transform: translate(0); opacity: 1; }
+  10% { transform: translate(2px, -2px); opacity: 0.8; }
+  20% { transform: translate(4px, 2px); opacity: 0.9; }
+  30% { transform: translate(-2px, -1px); opacity: 0.7; }
+  40% { transform: translate(-1px, 1px); opacity: 0.8; }
+  50% { transform: translate(1px, -2px); opacity: 0.9; }
+  60% { transform: translate(3px, -1px); opacity: 0.7; }
+  70% { transform: translate(-2px, -1px); opacity: 0.8; }
+  80% { transform: translate(1px, 1px); opacity: 0.9; }
+  90% { transform: translate(-1px, -2px); opacity: 0.7; }
+}
+
+@keyframes liquid {
+  0%, 100% { border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%; }
+  25% { border-radius: 30% 60% 70% 40% / 50% 60% 30% 60%; }
+  50% { border-radius: 40% 60% 40% 20% / 60% 50% 80% 30%; }
+  75% { border-radius: 70% 30% 60% 30% / 30% 80% 40% 60%; }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-10px); }
+}
+
+@keyframes slideInUp {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeInScale {
+  from {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,10 +17,10 @@ module.exports = {
         },
         bodyText: '#000000',
         noir: {
-          background: '#121212',
-          surface: '#181818',
-          text: '#e8e6e3',
-          accent: '#8be9fd',
+          background: 'var(--background)',
+          surface: 'var(--card)',
+          text: 'var(--foreground)',
+          accent: 'var(--noir-red)',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- integrate Dark Noir theme variables and animations into global styles
- map Tailwind noir palette to CSS variables for consistent styling

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f3f26a98832592b56d4d4ac326d8