### PR TITLE
Add scroll margins so anchored sections clear fixed header

### DIFF
--- a/src/components/DarkNoirAbout.tsx
+++ b/src/components/DarkNoirAbout.tsx
@@ -20,7 +20,7 @@ const stats = [
 ];
 
 const DarkNoirAbout = forwardRef<HTMLElement>((_, ref) => (
-  <section ref={ref} id="about" className="min-h-screen bg-black pt-16 text-white">
+  <section ref={ref} id="about" className="min-h-screen bg-black pt-16 text-white scroll-mt-28">
     <div className="mx-auto max-w-6xl px-6 py-24 lg:px-8">
       <div className="mb-20">
         <h2 className="mb-6 text-4xl md:text-5xl">About</h2>

--- a/src/components/DarkNoirContact.tsx
+++ b/src/components/DarkNoirContact.tsx
@@ -59,7 +59,7 @@ const DarkNoirContact = forwardRef<HTMLElement>((_, ref) => {
   };
 
   return (
-    <section ref={ref} id="contact" className="min-h-screen bg-black pt-16 text-white">
+    <section ref={ref} id="contact" className="min-h-screen bg-black pt-16 text-white scroll-mt-28">
       <div className="mx-auto max-w-6xl px-6 py-24 lg:px-8">
         <div className="mb-20">
           <h2 className="mb-6 text-4xl md:text-5xl">Let's Work Together</h2>

--- a/src/components/DarkNoirPortfolio.tsx
+++ b/src/components/DarkNoirPortfolio.tsx
@@ -133,7 +133,7 @@ const DarkNoirPortfolio = forwardRef<HTMLElement>((_, forwardedRef) => {
     <section
       ref={setRefs}
       id="work"
-      className="relative overflow-hidden bg-gradient-to-b from-black via-gray-950 to-black py-32 film-grain"
+      className="relative overflow-hidden bg-gradient-to-b from-black via-gray-950 to-black py-32 film-grain scroll-mt-28"
     >
       <div
         className="absolute h-96 w-96 rounded-full bg-red-500 opacity-[0.03] blur-3xl transition-all duration-1000"


### PR DESCRIPTION
## Summary
- add a scroll margin to the work, about, and contact sections so anchor navigation clears the fixed header

## Testing
- npm run lint *(fails: ESLint flat config does not support "extends" in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c896853c4c8325aed45a632eefccb2